### PR TITLE
Using JSONAssert instead of string validation for testProtoStructWithArray

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -174,6 +174,12 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${jsonassert.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -31,8 +31,11 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import java.io.IOException;
 import java.util.List;
@@ -389,7 +392,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
   }
 
   @Test
-  public void testProtoStructWithArray() throws IOException
+  public void testProtoStructWithArray() throws IOException, JSONException
   {
     final String file = "example/compat/proto-struct-with-array.parquet";
     InputRowSchema schema = new InputRowSchema(
@@ -435,6 +438,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), JSONCompareMode.LENIENT);
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -46,7 +46,7 @@ import java.util.List;
 public class CompatParquetReaderTest extends BaseParquetReaderTest
 {
   @Test
-  public void testBinaryAsString() throws IOException
+  public void testBinaryAsString() throws IOException, JSONException
   {
     final String file = "example/compat/284a0e001476716b-56d5676f53bd6e85_115466471_data.0.parq";
     InputRowSchema schema = new InputRowSchema(
@@ -97,21 +97,18 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), JSONCompareMode.LENIENT);
 
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(
-        expectedJsonBinary,
-        DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())
-    );
+    JSONAssert.assertEquals(expectedJsonBinary, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues()), JSONCompareMode.LENIENT);
   }
 
 
   @Test
-  public void testParquet1217() throws IOException
+  public void testParquet1217() throws IOException, JSONException
   {
     final String file = "example/compat/parquet-1217.parquet";
     InputRowSchema schema = new InputRowSchema(
@@ -146,11 +143,11 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), JSONCompareMode.LENIENT);
   }
 
   @Test
-  public void testParquetThriftCompat() throws IOException
+  public void testParquetThriftCompat() throws IOException, JSONException
   {
     /*
       message ParquetSchema {
@@ -308,11 +305,11 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), JSONCompareMode.LENIENT);
   }
 
   @Test
-  public void testOldRepeatedInt() throws IOException
+  public void testOldRepeatedInt() throws IOException, JSONException
   {
     final String file = "example/compat/old-repeated-int.parquet";
     InputRowSchema schema = new InputRowSchema(
@@ -345,12 +342,12 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), JSONCompareMode.LENIENT);
   }
 
 
   @Test
-  public void testReadNestedArrayStruct() throws IOException
+  public void testReadNestedArrayStruct() throws IOException, JSONException
   {
     final String file = "example/compat/nested-array-struct.parquet";
     InputRowSchema schema = new InputRowSchema(
@@ -388,7 +385,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), JSONCompareMode.LENIENT);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <scala.library.version>2.13.11</scala.library.version>
         <avatica.version>1.23.0</avatica.version>
         <avro.version>1.11.1</avro.version>
+        <jsonassert.version>1.5.1</jsonassert.version>
         <!-- When updating Calcite, also propagate updates to these files which we've copied and modified:
              default_config.fmpp
           -->


### PR DESCRIPTION
The test ```org.apache.druid.data.input.parquet.CompatParquetReaderTest#testProtoStructWithArray``` compares the first item of the list of ```InputRowListPlusRawValues``` returned from function ```createReader``` as stringified JSON object with hardcoded string. However ```DEFAULT_JSON_WRITER.writeValueAsString``` which is being used in the test doesn't return deterministic stringified JSON. The root cause of this issue is the nondeterministic behavior of the order of the returned fields for the object of ```InputRowListPlusRawValues```.
The function ```DEFAULT_JSON_WRITER.writeValueAsString``` is calling ```ObjectWriter._writeValueAndClose``` which serializes the object and there is no guarantee that the sequence of the fields returned will be the same every time. This brings the indeterministic behavior of the function and eventually makes the test **flaky**.

The proposed change introduces the use of ```JSONAssert.assertEquals``` with ```LENIENT``` mode, which verifies the stringified  JSON object's key and value with the expected stringified object irrespective of the sequence of the key-value pairs.

The change brings deterministic behavior in the test execution.

Through this PR, I have fixed the flaky behavior of all tests from the ```org.apache.druid.data.input.parquet.CompatParquetReaderTest``` file.
Fixed tests: 

1. testBinaryAsString
2. testParquet1217
3. testParquetThriftCompat
4. testOldRepeatedInt
5. testReadNestedArrayStruct
6. testProtoStructWithArray